### PR TITLE
Feature/ecl data

### DIFF
--- a/source/DD4T.ContentModel.Contracts/IComponent.cs
+++ b/source/DD4T.ContentModel.Contracts/IComponent.cs
@@ -19,5 +19,6 @@
         int Version { get; }
         DateTime LastPublishedDate { get; }
         DateTime RevisionDate { get; }
+        string EclId { get; }
     }
 }

--- a/source/DD4T.ContentModel.Contracts/IModel.cs
+++ b/source/DD4T.ContentModel.Contracts/IModel.cs
@@ -7,5 +7,6 @@ namespace DD4T.ContentModel
 {
     public interface IModel
     {
+        IDictionary<string, IFieldSet> ExtensionData { get; }
     }
 }

--- a/source/DD4T.ContentModel/ContentModel.cs
+++ b/source/DD4T.ContentModel/ContentModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -457,6 +458,56 @@ namespace DD4T.ContentModel
         IDictionary<string, IFieldSet> IModel.ExtensionData
         {
             get { return ExtensionData; }
+        }
+
+        public void AddExtensionProperty(string sectionName, string propertyName, object value)
+        {
+            if (ExtensionData == null)
+            {
+                ExtensionData = new SerializableDictionary<string, IFieldSet, FieldSet>();
+            }
+
+            IFieldSet sectionFieldSet;
+            if (!ExtensionData.TryGetValue(sectionName, out sectionFieldSet))
+            {
+                sectionFieldSet = new FieldSet();
+                ExtensionData.Add(sectionName, sectionFieldSet);
+            }
+
+            IField propertyField;
+            if (!sectionFieldSet.TryGetValue(propertyName, out propertyField))
+            {
+                propertyField = new Field { Name = propertyName };
+                sectionFieldSet.Add(propertyName, propertyField);
+            }
+
+            if (value is IEnumerable && !(value is string))
+            {
+                foreach (object item in (IEnumerable) value)
+                {
+                    AddFieldValue(propertyField, item);
+                }
+            }
+            else
+            {
+                AddFieldValue(propertyField, value);
+            }
+        }
+
+        private static void AddFieldValue(IField field, object value)
+        {
+            if (value is int || value is long || value is double)
+            {
+                field.NumericValues.Add(Convert.ToDouble(value));
+            }
+            else if (value is DateTime)
+            {
+                field.DateTimeValues.Add((DateTime) value);
+            }
+            else
+            {
+                field.Values.Add(value.ToString());
+            }
         }
     }
 

--- a/source/DD4T.ContentModel/ContentModel.cs
+++ b/source/DD4T.ContentModel/ContentModel.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
-using System.Xml;
 using System.Xml.Serialization;
 
 namespace DD4T.ContentModel
@@ -119,7 +118,7 @@ namespace DD4T.ContentModel
         { get { return Keywords.ToList<IKeyword>(); } }
     }
 
-    public class ComponentPresentation : IComponentPresentation
+    public class ComponentPresentation : Model, IComponentPresentation
     {
         [XmlIgnore]
         public IPage Page { get; set; }
@@ -238,6 +237,8 @@ namespace DD4T.ContentModel
         }
 
         public int Version { get; set; }
+
+        public string EclId { get; set; }
 
         #endregion Properties
 
@@ -447,7 +448,20 @@ namespace DD4T.ContentModel
         #endregion Constructors
     }
 
-    public abstract class TridionItem : IItem
+
+    public abstract class Model : IModel
+    {
+        public SerializableDictionary<string, IFieldSet, FieldSet> ExtensionData { get; set; }
+
+        [XmlIgnore]
+        IDictionary<string, IFieldSet> IModel.ExtensionData
+        {
+            get { return ExtensionData; }
+        }
+    }
+
+
+    public abstract class TridionItem : Model, IItem
     {
         public string Id { get; set; }
         public string Title { get; set; }

--- a/source/DD4T.ContentModel/ContentModel.cs
+++ b/source/DD4T.ContentModel/ContentModel.cs
@@ -285,6 +285,28 @@ namespace DD4T.ContentModel
 
     public class Field : IField
     {
+        #region JSON serialization control
+        // NOTE: we're simply supressing some properties from JSON serialization here. Normally you would use the [JsonIgnore] attribute for that purpose.
+        // However, we are using JSON.NET conditional serialization feature (ShouldSerializeXYZ) here to avoid a direct reference to JSON.NET.
+
+        /// <summary>
+        /// Supresses JSON serialization of the <see cref="Value"/> property (which is only a convenience property derived from <see cref="Values"/>)
+        /// </summary>
+        public bool ShouldSerializeValue()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Supresses JSON serialization of the <see cref="Keywords"/> property (which is only a legacy property derived from <see cref="KeywordValues"/>)
+        /// </summary>
+        public bool ShouldSerializeKeywords()
+        {
+            return false;
+        }
+        #endregion
+
+
         #region Properties
         public string Name
         {
@@ -399,15 +421,6 @@ namespace DD4T.ContentModel
         {
             get;
             set;
-        }
-
-        /// <summary>
-        /// This method is used by NewtonSoft to determine whether or not to serialize the Keywords property
-        /// </summary>
-        /// <returns></returns>
-        public bool ShouldSerializeKeywords()
-        {
-            return false;
         }
 
         [XmlIgnore]

--- a/source/DD4T.Model.Test/BaseSerialization.cs
+++ b/source/DD4T.Model.Test/BaseSerialization.cs
@@ -140,6 +140,7 @@ namespace DD4T.Model.Test
             modelImpl.AddExtensionProperty("test1", "testProperty1a", new [] { "this", "is", "a", "test" });
             modelImpl.AddExtensionProperty("test1", "testProperty1b", 3.1415);
             modelImpl.AddExtensionProperty("test2", "testProperty2a", new DateTime(1970, 12, 16));
+            modelImpl.AddExtensionProperty("test3", "dummyProperty", null); // This should not do anything
         }
 
         protected abstract ISerializerService GetService(bool compressionEnabled);

--- a/source/DD4T.Model.Test/BaseSerialization.cs
+++ b/source/DD4T.Model.Test/BaseSerialization.cs
@@ -136,34 +136,10 @@ namespace DD4T.Model.Test
 
         protected static void SetTestExtensionData(IModel model)
         {
-            Field testField1A = new Field()
-            {
-                Name = "testField1a",
-                Values = new List<string> { "this", "is", "a", "test" }
-            };
-            Field testField1B = new Field()
-            {
-                Name = "testField1b",
-                NumericValues = new List<double> { 1.0, 2.1, 3.2345 }
-            };
-            Field testField2A = new Field()
-            {
-                Name = "testField2a",
-                DateTimeValues = new List<DateTime> { new DateTime(1970, 12, 16) }
-            };
-
             ContentModel.Model modelImpl = (ContentModel.Model) model;
-            modelImpl.ExtensionData = new SerializableDictionary<string, IFieldSet, FieldSet>();
-
-            model.ExtensionData.Add("test1", new FieldSet
-            {
-                { testField1A.Name, testField1A },
-                { testField1B.Name, testField1B }
-            });
-            model.ExtensionData.Add("test2", new FieldSet
-            {
-                { testField2A.Name, testField2A }
-            });
+            modelImpl.AddExtensionProperty("test1", "testProperty1a", new [] { "this", "is", "a", "test" });
+            modelImpl.AddExtensionProperty("test1", "testProperty1b", 3.1415);
+            modelImpl.AddExtensionProperty("test2", "testProperty2a", new DateTime(1970, 12, 16));
         }
 
         protected abstract ISerializerService GetService(bool compressionEnabled);

--- a/source/DD4T.Model.Test/BaseSerialization.cs
+++ b/source/DD4T.Model.Test/BaseSerialization.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using DD4T.ContentModel;
-using DD4T.Serialization;
 using DD4T.ContentModel.Contracts.Serializing;
 using System.Collections.Generic;
 using System.Linq;
@@ -141,6 +140,8 @@ namespace DD4T.Model.Test
             modelImpl.AddExtensionProperty("test1", "testProperty1b", 3.1415);
             modelImpl.AddExtensionProperty("test2", "testProperty2a", new DateTime(1970, 12, 16));
             modelImpl.AddExtensionProperty("test3", "dummyProperty", null); // This should not do anything
+
+            Assert.IsFalse(modelImpl.ExtensionData.ContainsKey("test3"), "Adding a null value should not do anything.");
         }
 
         protected abstract ISerializerService GetService(bool compressionEnabled);
@@ -161,6 +162,40 @@ namespace DD4T.Model.Test
         }
 
 
+        protected void AssertEqualFieldSets(IFieldSet expected, IFieldSet actual)
+        {
+            Assert.IsTrue(actual.Keys.SequenceEqual(expected.Keys), "FieldSets have different Keys.");
+
+            foreach (IField field in expected.Values)
+            {
+                IField deserializedField = actual[field.Name];
+                Assert.AreEqual(field.FieldType, deserializedField.FieldType, "FieldType");
+                switch (field.FieldType)
+                {
+                    case FieldType.Number:
+                        Assert.IsNotNull(deserializedField.NumericValues, "NumericValues");
+                        Assert.IsTrue(deserializedField.NumericValues.SequenceEqual(field.NumericValues), "NumericValues");
+                        break;
+
+                    case FieldType.Date:
+                        Assert.IsNotNull(deserializedField.DateTimeValues, "DateTimeValues");
+                        Assert.IsTrue(deserializedField.DateTimeValues.SequenceEqual(field.DateTimeValues), "DateTimeValues");
+                        break;
+
+                    case FieldType.Embedded:
+                        Assert.IsNotNull(deserializedField.EmbeddedValues, "EmbeddedValues");
+                        Assert.AreEqual(deserializedField.EmbeddedValues.Count, field.EmbeddedValues.Count, "#EmbeddedValues");
+                        break;
+
+                    default:
+                        Assert.IsNotNull(deserializedField.Values, "Values");
+                        Assert.IsTrue(deserializedField.Values.SequenceEqual(field.Values), "Values");
+                        break;
+                }
+            }
+        }
+
+
         [TestMethod]
         public void SerializeDeserializeComponentWithExtensionData()
         {
@@ -172,6 +207,12 @@ namespace DD4T.Model.Test
             Assert.IsNotNull(deserializedComponent.ExtensionData, "ExtensionData");
             Assert.AreEqual(testComponent.ExtensionData.Count, deserializedComponent.ExtensionData.Count, "#ExtensionData");
             Assert.IsTrue(deserializedComponent.ExtensionData.Keys.SequenceEqual(testComponent.ExtensionData.Keys), "ExtensionData.Keys");
+
+            foreach (KeyValuePair<string, IFieldSet> extensionDataSection in testComponent.ExtensionData)
+            {
+                IFieldSet deserializedFieldSet = deserializedComponent.ExtensionData[extensionDataSection.Key];
+                AssertEqualFieldSets(extensionDataSection.Value, deserializedFieldSet);
+            }
         }
 
         [TestMethod]

--- a/source/DD4T.Model.Test/JsonSerialization.cs
+++ b/source/DD4T.Model.Test/JsonSerialization.cs
@@ -5,6 +5,8 @@ using DD4T.Serialization;
 using DD4T.ContentModel.Contracts.Serializing;
 using System.Timers;
 using System.Diagnostics;
+using System.Linq;
+using System.Runtime.Remoting.Channels;
 
 namespace DD4T.Model.Test
 {
@@ -26,10 +28,14 @@ namespace DD4T.Model.Test
         {
             testComponent = GenerateTestComponent();
             testComponentPresentation = GenerateTestComponentPresentation();
-            testComponentJson = GetService(false).Serialize<IComponent>(testComponent);
-            testComponentJsonCompressed = GetService(true).Serialize<IComponent>(testComponent);
-            testComponentPresentationJson = GetService(false).Serialize<IComponentPresentation>(testComponentPresentation);
-            testComponentPresentationJsonCompressed = GetService(true).Serialize<IComponentPresentation>(testComponentPresentation);
+
+            // Method GetService() is a (virtual) instance method now, so we need a temp instance.
+            JsonSerialization testInstance = new JsonSerialization();
+
+            testComponentJson = testInstance.GetService(false).Serialize<IComponent>(testComponent);
+            testComponentJsonCompressed = testInstance.GetService(true).Serialize<IComponent>(testComponent);
+            testComponentPresentationJson = testInstance.GetService(false).Serialize<IComponentPresentation>(testComponentPresentation);
+            testComponentPresentationJsonCompressed = testInstance.GetService(true).Serialize<IComponentPresentation>(testComponentPresentation);
         }
 
 
@@ -133,7 +139,6 @@ namespace DD4T.Model.Test
         }
 
 
-
         private T GetTestModel<T>() where T : IModel
         {
             if (typeof(T) == typeof(Component))
@@ -225,7 +230,7 @@ namespace DD4T.Model.Test
             stopwatch.Stop();
         }
         
-        private static ISerializerService GetService(bool compressionEnabled)
+        protected override ISerializerService GetService(bool compressionEnabled)
         {
             if (!services.ContainsKey(compressionEnabled))
             {

--- a/source/DD4T.Model.Test/XmlSerialization.cs
+++ b/source/DD4T.Model.Test/XmlSerialization.cs
@@ -30,12 +30,16 @@ namespace DD4T.Model.Test
             testComponent = GenerateTestComponent();
             testComponentPresentation = GenerateTestComponentPresentation();
             testPage = GenerateTestPage();
-            testComponentXml = GetService(false).Serialize<IComponent>(testComponent);
-            testComponentXmlCompressed = GetService(true).Serialize<IComponent>(testComponent);
-            testComponentPresentationXml = GetService(false).Serialize<IComponentPresentation>(testComponentPresentation);
-            testComponentPresentationXmlCompressed = GetService(true).Serialize<IComponentPresentation>(testComponentPresentation);
-            testPageXml = GetService(false).Serialize<IPage>(testPage);
-            testPageXmlCompressed = GetService(true).Serialize<IPage>(testPage);
+
+            // Method GetService() is a (virtual) instance method now, so we need a temp instance.
+            XmlSerialization testInstance = new XmlSerialization();
+
+            testComponentXml = testInstance.GetService(false).Serialize<IComponent>(testComponent);
+            testComponentXmlCompressed = testInstance.GetService(true).Serialize<IComponent>(testComponent);
+            testComponentPresentationXml = testInstance.GetService(false).Serialize<IComponentPresentation>(testComponentPresentation);
+            testComponentPresentationXmlCompressed = testInstance.GetService(true).Serialize<IComponentPresentation>(testComponentPresentation);
+            testPageXml = testInstance.GetService(false).Serialize<IPage>(testPage);
+            testPageXmlCompressed = testInstance.GetService(true).Serialize<IPage>(testPage);
         }
 
 
@@ -263,7 +267,7 @@ namespace DD4T.Model.Test
             stopwatch.Stop();
         }
 
-        private static ISerializerService GetService(bool compressionEnabled)
+        protected override ISerializerService GetService(bool compressionEnabled)
         {
             if (!services.ContainsKey(compressionEnabled))
             {

--- a/source/DD4T.Serialization/JSONSerializerService.cs
+++ b/source/DD4T.Serialization/JSONSerializerService.cs
@@ -17,10 +17,13 @@ namespace DD4T.Serialization
             get
             {
                 if (_serializer == null)
-                {  
-                    _serializer = new JsonSerializer();
-                    _serializer.NullValueHandling = NullValueHandling.Ignore;
+                {
+                    _serializer = new JsonSerializer
+                    {
+                        NullValueHandling = NullValueHandling.Ignore
+                    };
                     _serializer.Converters.Add(new FieldConverter());
+                    _serializer.Converters.Add(new FieldSetConverter());
                 }
 
                 return _serializer;
@@ -84,4 +87,13 @@ namespace DD4T.Serialization
             return new Field();
         }
     }
+
+    public class FieldSetConverter : CustomCreationConverter<IFieldSet>
+    {
+        public override IFieldSet Create(Type objectType)
+        {
+            return new FieldSet();
+        }
+    }
+
 }


### PR DESCRIPTION
Added support for addition ECL data using a general extension mechanism, as discussed earlier:
IModel.ExtensionData
IComponent.EclId

Also suppressing Field.Value property from JSON; it's just redundant data in the JSON.
