### PR TITLE
Fix for concurrency issue in JSONSerializerService.

### DIFF
--- a/source/DD4T.Serialization/JSONSerializerService.cs
+++ b/source/DD4T.Serialization/JSONSerializerService.cs
@@ -10,7 +10,7 @@ namespace DD4T.Serialization
     public class JSONSerializerService : BaseSerializerService
     {
 
-
+        private object _lock = new object();
         private JsonSerializer _serializer = null;
         public JsonSerializer Serializer
         {
@@ -18,12 +18,18 @@ namespace DD4T.Serialization
             {
                 if (_serializer == null)
                 {
-                    _serializer = new JsonSerializer
+                    lock (_lock)
                     {
-                        NullValueHandling = NullValueHandling.Ignore
-                    };
-                    _serializer.Converters.Add(new FieldConverter());
-                    _serializer.Converters.Add(new FieldSetConverter());
+                        if (_serializer == null)
+                        {
+                            _serializer = new JsonSerializer
+                            {
+                                NullValueHandling = NullValueHandling.Ignore
+                            };
+                            _serializer.Converters.Add(new FieldConverter());
+                            _serializer.Converters.Add(new FieldSetConverter());
+                        }
+                    }
                 }
 
                 return _serializer;


### PR DESCRIPTION
Fix for issue https://github.com/dd4t/DD4T.Core/issues/100
I was able to reproduce it using load testing (50 concurrent users) and recycling app pool in IIS. Under this circumstances during startup JSONSerializerService enters into a state when it always throws NullReferenceException because there is a null in Converters collection of its Serializer.